### PR TITLE
Adds ability to set class name as part of parlour dsl.

### DIFF
--- a/src/main/scala/au/com/cba/omnia/parlour/SqoopSyntax.scala
+++ b/src/main/scala/au/com/cba/omnia/parlour/SqoopSyntax.scala
@@ -206,6 +206,11 @@ trait ParlourOptions[+Self <: ParlourOptions[_]] extends ParlourDsl[Self] with C
   addOptional("job-name", (v: String) => so => so.setJobName(v))
   def getJobName = Option(toSqoopOptions.getJobName)
 
+  /** Sets the class name of the sqoop job. */
+  def className(name: String) = update(_.setClassName(name))
+  addOptional("class-name", (v: String) => so => so.setClassName(v))
+  def getClassName = Option(toSqoopOptions.getClassName)
+
   /** Hadoop Configuration */
   private[parlour] def config(config: Configuration) = update(_.setConf(config))
   private[parlour] def getConfig = Option(toSqoopOptions.getConf)


### PR DESCRIPTION
Need to add the ability to set the class name instead of job name.