### PR TITLE
Fixes bug in `inputNull` in SqoopExportSyntax.

### DIFF
--- a/src/main/scala/au/com/cba/omnia/parlour/SqoopSyntax.scala
+++ b/src/main/scala/au/com/cba/omnia/parlour/SqoopSyntax.scala
@@ -258,9 +258,9 @@ trait ParlourExportOptions[+Self <: ParlourExportOptions[_]] extends ParlourOpti
   def getInputNullNonString = Option(toSqoopOptions.getInNullNonStringValue)
 
   /** The string to be interpreted as null for input string and input non-string columns */
-  def inputNull(token: String) = {
-    inputNullString(token)
-    inputNullNonString(token)
+  def inputNull(token: String) = update { conf =>
+    conf.setInNullNonStringValue(token)
+    conf.setInNullStringValue(token)
   }
 }
 

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.6.0"
+version in ThisBuild := "1.6.1"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
This closes #62.

`inputNull` was calling both `inputNullNonString` and `inputNullString`. Unfortunately, it wasn't chaining the calls together causing the result of `inputNullString` to be dropped. This bug was probably introduced when chaning from mutable to immutable.