### PR TITLE
Adding support to remove/replace new line and cntl-A character during sqoop import

### DIFF
--- a/src/main/scala/au/com/cba/omnia/parlour/SqoopSyntax.scala
+++ b/src/main/scala/au/com/cba/omnia/parlour/SqoopSyntax.scala
@@ -310,6 +310,16 @@ trait ParlourImportOptions[+Self <: ParlourImportOptions[_]] extends ParlourOpti
   def linesTerminatedBy(c: Char) = update(_.setLinesTerminatedBy(c))
   addOptional("lines-terminated-by", (v: Char) => so => so.setLinesTerminatedBy(v), _.head, Some('\n'))
   def getLinesTerminatedBy = Option(toSqoopOptions.getOutputRecordDelim)
+
+  /** Remove \n, \r and \01 from String columns */
+  def hiveDropImportDelims() = update(_.setHiveDropDelims(true))
+  addBoolean("hive-drop-import-delims", () => so => so.setHiveDropDelims(true))
+  def getHiveDropImportDelims = Option(toSqoopOptions.doHiveDropDelims)
+
+  /** Replace \n, \r and \01 with a given string `replacement` from String columns */
+  def hiveImportDelimsReplacement(replacement: String) = update(_.setHiveDelimsReplacement(replacement))
+  addOptionalS("hive-delims-replacement", (v: String) => so => so.setHiveDelimsReplacement(v))
+  def getHiveImportDelimsReplacement = Option(toSqoopOptions.getHiveDelimsReplacement)
 }
 
 /**

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.9.0"
+version in ThisBuild := "1.10.0"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
This is to make use of sqoop parameters  `--hive-drop-import-delims` and `--hive-delims-replacement`.

This allow users to remove/ replace `\n, \r, \001`  from string columns during Sqoop import.