### PR TITLE
Added Sqoop option for direct mode to API

### DIFF
--- a/src/main/scala/au/com/cba/omnia/parlour/SqoopSyntax.scala
+++ b/src/main/scala/au/com/cba/omnia/parlour/SqoopSyntax.scala
@@ -212,6 +212,11 @@ trait ParlourOptions[+Self <: ParlourOptions[_]] extends ParlourDsl[Self] with C
   addOptionalS("class-name", (v: String) => so => so.setClassName(v))
   def getClassName = Option(toSqoopOptions.getClassName)
 
+  /** Enable the Sqoop job to utilize database specific native features if applicable */
+  def directMode(v: Boolean) = update(_.setDirectMode(v))
+  addBoolean("direct", () => so => so.setDirectMode(true))
+  def isDirectMode = Option(toSqoopOptions.isDirect)
+
   /** Hadoop Configuration */
   private[parlour] def config(config: Configuration) = update(_.setConf(config))
   private[parlour] def getConfig = Option(toSqoopOptions.getConf)

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.11.0"
+version in ThisBuild := "1.11.1"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
Adding this option will enable Sqoop to use native database features for importing or exporting data, if they are available.