### PR TITLE
Adding support for Teradata export option --error-database available from connector 1.4c5

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@
 
 resolvers += Resolver.url("commbank-releases-ivy", new URL("http://commbank.artifactoryonline.com/commbank/ext-releases-local-ivy"))(Patterns("[organization]/[module]_[scalaVersion]_[sbtVersion]/[revision]/[artifact](-[classifier])-[revision].[ext]"))
 
-val uniformVersion = "1.6.0-20160104234203-3ff47bf"
+val uniformVersion = "1.11.1-20160627055835-9eab1f7"
 
 addSbtPlugin("au.com.cba.omnia" % "uniform-core"       % uniformVersion)
 

--- a/src/main/scala/au/com/cba/omnia/parlour/SqoopSyntax.scala
+++ b/src/main/scala/au/com/cba/omnia/parlour/SqoopSyntax.scala
@@ -502,12 +502,18 @@ trait TeradataParlourExportOptions[+Self <: TeradataParlourExportOptions[_]] ext
   def fastloadSocketHostName(hostname: String) = addExtraArgs(Array(FASTLOAD_SOCKET_HOSTNAME, hostname))
   addOptionalS("teradata-fastload-socket-hostname", (v: String) => so => addExtraArgsRaw(Array(FASTLOAD_SOCKET_HOSTNAME, v))(so))
   def getFastloadSocketHostName = getExtraValueArg(FASTLOAD_SOCKET_HOSTNAME)
+
+  /** Specifies database for creating error tables. (only for internal.fastload and supported only from teradata connector 1.4c5) */
+  def errorDatabase(dbName: String) = addExtraArgs(Array(ERROR_DATABASE, dbName))
+  addOptionalS("teradata-error-database", (v: String) => so => addExtraArgsRaw(Array(ERROR_DATABASE, v))(so))
+  def getErrorDatabase = getExtraValueArg(ERROR_DATABASE)
 }
 
 object TeradataParlourExportOptions {
   val OUTPUT_METHOD             = "--output-method"
   val ERROR_TABLE               = "--error-table"
   val FASTLOAD_SOCKET_HOSTNAME  = "--fastload-socket-hostname"
+  val ERROR_DATABASE            = "--error-database"
 }
 
 trait ConsoleOptions[+Self <: ParlourOptions[_]] {

--- a/src/test/scala/au/com/cba/omnia/parlour/SqoopSyntaxSpec.scala
+++ b/src/test/scala/au/com/cba/omnia/parlour/SqoopSyntaxSpec.scala
@@ -193,6 +193,7 @@ Should build proper SqoopOptions:
       val username = "some username"
       val password = "some password"
       val tableName = "some table"
+      val errorDb = "errorDB"
 
       //when
       val sqoopOpts = TeradataParlourExportDsl()
@@ -201,10 +202,11 @@ Should build proper SqoopOptions:
         .username(username)
         .password(password)
         .tableName(tableName)
+        .errorDatabase(errorDb)
         .toSqoopOptions
 
       //then
-      sqoopOpts.getExtraArgs must beEqualTo(Array("--output-method", "batch.insert"))
+      sqoopOpts.getExtraArgs must beEqualTo(Array("--output-method", "batch.insert", "--error-database", "errorDB"))
       sqoopOpts.getConnectString must beEqualTo(connString)
       sqoopOpts.getUsername must beEqualTo(username)
       sqoopOpts.getPassword must beEqualTo(password)

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.11.2"
+version in ThisBuild := "1.12.0"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
This is to add support for Teradata export option --error-database  which is available from connector version 1.4c5. This allows application using parlour and connector version 1.4c5  to override database where error tables are created during internal.fastload.