### PR TITLE
Correcting teradata connector export parameter names as per documenation

### DIFF
--- a/src/main/scala/au/com/cba/omnia/parlour/SqoopSyntax.scala
+++ b/src/main/scala/au/com/cba/omnia/parlour/SqoopSyntax.scala
@@ -367,7 +367,7 @@ trait TeradataParlourOptions[+Self <: TeradataParlourOptions[_]] extends Parlour
 
   /** Force the connector to create the staging table if input/output method support the staging tables. */
   def forceStaging() = addExtraArgs(Array(FORCE_STAGING))
-  addBoolean("teradata-force-staging", () => so => addExtraArgsRaw(Array(FORCE_STAGING))(so))
+  addBoolean("teradata-staging-force", () => so => addExtraArgsRaw(Array(FORCE_STAGING))(so))
   def getForceStaging = getExtraBooleanArg(FORCE_STAGING)
 
   /**
@@ -380,7 +380,7 @@ trait TeradataParlourOptions[+Self <: TeradataParlourOptions[_]] extends Parlour
 
   /** By default, the connector will use Teradata system views to obtain metadata. Using this parameter the connector will switch to XViews instead. */
   def skipXviews() = addExtraArgs(Array(SKIP_VIEW))
-  addBoolean("teradata-skip-xview", () => so => addExtraArgsRaw(Array(SKIP_VIEW))(so))
+  addBoolean("teradata-skip-xviews", () => so => addExtraArgsRaw(Array(SKIP_VIEW))(so))
   def getSkipXviews = getExtraBooleanArg(SKIP_VIEW)
 }
 
@@ -388,9 +388,9 @@ object TeradataParlourOptions {
   val STAGING_TABLE     = "--staging-table"
   val STAGING_DATABASE  = "--staging-database"
   val BATCH_SIZE        = "--batch-size"
-  val FORCE_STAGING     = "--force-staging"
+  val FORCE_STAGING     = "--staging-force"
   val QUERY_BAND        = "--query-band"
-  val SKIP_VIEW         = "--skip-xview"
+  val SKIP_VIEW         = "--skip-xviews"
 }
 
 sealed trait TeradataInputMethod

--- a/src/test/scala/au/com/cba/omnia/parlour/SqoopSyntaxSpec.scala
+++ b/src/test/scala/au/com/cba/omnia/parlour/SqoopSyntaxSpec.scala
@@ -65,11 +65,11 @@ Should build proper SqoopOptions:
 
     def extraArgsViaAddBoolean = {
       //given
-      val args = Args("--teradata-skip-xview" :: requiredSqoopImportArgList)
+      val args = Args("--teradata-skip-xviews" :: "--teradata-staging-force" :: requiredSqoopImportArgList)
       //when
       val so = TeradataParlourImportDsl().setOptions(args).toSqoopOptions
       //then
-      so.getExtraArgs must beEqualTo(Array("--skip-xview"))
+      so.getExtraArgs must beEqualTo(Array("--staging-force", "--skip-xviews"))
     }
 
     def extraArgsViaAddOptional = {

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.12.3"
+version in ThisBuild := "1.12.4"
 
 localVersionSettings
 


### PR DESCRIPTION
Teradata connector boolean parameters were typed incorrectly. Correcting the same as per documenation  http://www.cloudera.com/documentation/other/connectors/teradata/1-x/topics/cctd_use_tpcc.html
